### PR TITLE
Correct integer encodings for values greater than 127

### DIFF
--- a/ber_test.go
+++ b/ber_test.go
@@ -1,0 +1,20 @@
+package ber
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestEncode(t *testing.T) {
+	b := EncodeInteger(0)
+	assert.Equal(t, []byte{0}, b, "Encode of 0 failed")
+
+	b = EncodeInteger(127)
+	assert.Equal(t, []byte{0x7f}, b, "Encode of 127 failed")
+
+	b = EncodeInteger(128)
+	assert.Equal(t, []byte{0, 0x80}, b, "Encode of 128 failed")
+
+	b = EncodeInteger(256)
+	assert.Equal(t, []byte{1, 0}, b, "Encode of 256 failed")
+}


### PR DESCRIPTION
If you make more than 127 requests with ldap, you get errors without this fix
